### PR TITLE
feat: add code lint checker and rename import checker

### DIFF
--- a/cmd/nubitci-lint/main.go
+++ b/cmd/nubitci-lint/main.go
@@ -8,11 +8,13 @@ import (
 	"github.com/RiemaLabs/nubit-ci/internal/checkers"
 	"github.com/RiemaLabs/nubit-ci/internal/checkers/codeformats"
 	"github.com/RiemaLabs/nubit-ci/internal/checkers/commits"
+	"github.com/RiemaLabs/nubit-ci/internal/checkers/importformats"
 	"github.com/RiemaLabs/nubit-ci/internal/logs"
 )
 
 var C = []checkers.Checker{
 	new(commits.Checker),
+	new(importformats.Checker),
 	new(codeformats.Checker),
 }
 

--- a/internal/checkers/codeformats/codeformat.go
+++ b/internal/checkers/codeformats/codeformat.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/RiemaLabs/nubit-ci/internal/checkers"
@@ -14,35 +15,48 @@ type Checker struct{}
 func (*Checker) Name() string   { return "code-format" }
 func (*Checker) Install() error { return nil }
 
-const formatter = "golang.org/x/tools/cmd/goimports@latest"
+const formatter = "github.com/golangci/golangci-lint/cmd/golangci-lint@latest"
 
 func (*Checker) Check() error {
-	raw, err := checkers.GoRun(formatter, "-l", ".").CombinedOutput()
+	raw, err := checkers.GoRun(formatter, "run", "--show-stats").CombinedOutput()
 	if err != nil {
 		fmt.Println(string(raw))
 		return err
 	}
+	fmt.Println()
 	if output := string(bytes.TrimSpace(raw)); output != "" {
-		var files []string
-		for _, s := range strings.Split(output, "\n") {
+		lines := strings.Split(output, "\n")
+		cnt := -1
+		errInfo := ""
+		statsInfo := ""
+		for i, s := range lines {
 			line := strings.TrimSpace(s)
-			if strings.HasPrefix(line, "go:") {
-				continue
+			if strings.Contains(line, " issues") {
+				parts := strings.Split(line, " ")
+				cnt, _ = strconv.Atoi(parts[0])
+				if cnt != 0 {
+					errInfo = strings.Join(lines[:i], "\n")
+					statsInfo = strings.Join(lines[i:len(lines)-1], "\n")
+				} else {
+					statsInfo = strings.Join(lines[i:], "\n")
+				}
+				break
 			}
-			files = append(files, line)
 		}
-		if len(files) > 0 {
-			fmt.Printf("⚠️ %d file(s) not formatted:\n\n", len(files))
-			for _, f := range files {
-				fmt.Println("  *", f)
-			}
-			fmt.Println()
-			return errors.New("code not formatted")
+		if cnt == 0 {
+			fmt.Println("✅ No issue found! Code passed the lint check!")
+		} else if cnt > 0 {
+			fmt.Printf("⚠️ %d issue(s) found by lint:\n", cnt)
+			fmt.Println("Error info: ")
+			fmt.Println(errInfo)
+			fmt.Println("Statistic info")
+			fmt.Println(statsInfo)
+			return errors.New("code lint check failed")
+		} else {
+			return errors.New("unexpected errors occurred when run golangci-lint")
 		}
 	}
 	return nil
 }
 
-func (*Checker) Fix() error {
-	return checkers.Tee(checkers.GoRun(formatter, "-w", ".")).Run()
-}
+func (*Checker) Fix() error { return nil }

--- a/internal/checkers/importformats/importformat.go
+++ b/internal/checkers/importformats/importformat.go
@@ -1,0 +1,48 @@
+package importformats
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/RiemaLabs/nubit-ci/internal/checkers"
+)
+
+type Checker struct{}
+
+func (*Checker) Name() string   { return "import-format" }
+func (*Checker) Install() error { return nil }
+
+const formatter = "golang.org/x/tools/cmd/goimports@latest"
+
+func (*Checker) Check() error {
+	raw, err := checkers.GoRun(formatter, "-l", ".").CombinedOutput()
+	if err != nil {
+		fmt.Println(string(raw))
+		return err
+	}
+	if output := string(bytes.TrimSpace(raw)); output != "" {
+		var files []string
+		for _, s := range strings.Split(output, "\n") {
+			line := strings.TrimSpace(s)
+			if strings.HasPrefix(line, "go:") {
+				continue
+			}
+			files = append(files, line)
+		}
+		if len(files) > 0 {
+			fmt.Printf("⚠️ %d file(s) not formatted:\n\n", len(files))
+			for _, f := range files {
+				fmt.Println("  *", f)
+			}
+			fmt.Println()
+			return errors.New("code not formatted")
+		}
+	}
+	return nil
+}
+
+func (*Checker) Fix() error {
+	return checkers.Tee(checkers.GoRun(formatter, "-w", ".")).Run()
+}


### PR DESCRIPTION
1. Rename original `codeformats` to `importformats`
2. Add new `codeformats` to run `golangci-lint` checker.